### PR TITLE
予約枠の残数をアプリケーション側でのみチェック

### DIFF
--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -111,10 +111,7 @@ func reserveLivestreamHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get reservation_slots: "+err.Error())
 	}
 	for _, slot := range slots {
-		var count int
-		if err := tx.GetContext(ctx, &count, "SELECT slot FROM reservation_slots WHERE start_at = ? AND end_at = ?", slot.StartAt, slot.EndAt); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get reservation_slots: "+err.Error())
-		}
+		count := slot.Slot
 		c.Logger().Infof("%d ~ %d予約枠の残数 = %d\n", slot.StartAt, slot.EndAt, slot.Slot)
 		if count < 1 {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("予約期間 %d ~ %dに対して、予約区間 %d ~ %dが予約できません", termStartAt.Unix(), termEndAt.Unix(), req.StartAt, req.EndAt))


### PR DESCRIPTION
94564

```
2023-11-27T14:16:19.258Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-27T14:16:19.258Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-27T14:16:19.258Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-27T14:16:19.258Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-27T14:16:22.525Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-27T14:16:29.434Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-27T14:16:29.434Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-27T14:17:07.445Z	info	isupipe-benchmarker	DNS水責め負荷が上昇します	{"parallelis": 3}
2023-11-27T14:17:29.438Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-27T14:17:29.451Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "watanabekyosuke1", "livestream_id": 8178, "error": "Post \"https://hyoshida0.u.isucon.dev:443/api/livestream/8178/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:17:29.451Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "cinoue1", "livestream_id": 8181, "error": "Post \"https://fujiwarayoichi0.u.isucon.dev:443/api/livestream/8181/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:17:29.451Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "tanakaakemi0", "livestream_id": 7641, "error": "Post \"https://wito0.u.isucon.dev:443/api/livestream/7641/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:17:29.451Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "naokisato2", "livestream_id": 7733, "error": "Post \"https://fujiwarakenichi0.u.isucon.dev:443/api/livestream/7733/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:17:29.454Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "tanakamomoko1", "livestream_id": 8190, "error": "Post \"https://yukitanaka0.u.isucon.dev:443/api/livestream/8190/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:17:30.171Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-27T14:17:30.171Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-27T14:17:30.171Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-27T14:17:30.171Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-27T14:17:30.171Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 481}
```

<details><summary>以下は #17 入れる前のやつ</summary>

70100

スループットが上がりすぎている予感がするのでいったんつけおきにする

```
2023-11-27T14:09:55.113Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-27T14:09:55.113Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-27T14:09:55.113Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-27T14:09:55.113Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-27T14:09:58.292Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-27T14:10:05.216Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-27T14:10:05.216Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-27T14:10:47.224Z	info	isupipe-benchmarker	DNS水責め負荷が上昇します	{"parallelis": 3}
2023-11-27T14:11:05.224Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-27T14:11:05.226Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "xsuzuki1", "livestream_id": 7767, "error": "Post \"https://yokofukuda0.u.isucon.dev:443/api/livestream/7767/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:11:05.226Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "mmatsuda0", "livestream_id": 7573, "error": "Post \"https://atsushi410.u.isucon.dev:443/api/livestream/7573/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:11:05.227Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "zsuzuki0", "livestream_id": 7631, "error": "Post \"https://atanaka0.u.isucon.dev:443/api/livestream/7631/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:11:05.541Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-27T14:11:05.542Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-27T14:11:05.542Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-27T14:11:05.542Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-27T14:11:05.542Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 360}
```

</details>