### PR TITLE
配信のタグをbulk insert

### DIFF
--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hatena/godash"
 	"github.com/jmoiron/sqlx"
 	"github.com/labstack/echo-contrib/session"
 	"github.com/labstack/echo/v4"
@@ -145,14 +146,15 @@ func reserveLivestreamHandler(c echo.Context) error {
 	}
 	livestreamModel.ID = livestreamID
 
-	// タグ追加
-	for _, tagID := range req.Tags {
-		if _, err := tx.NamedExecContext(ctx, "INSERT INTO livestream_tags (livestream_id, tag_id) VALUES (:livestream_id, :tag_id)", &LivestreamTagModel{
+	ltModels := godash.Map(req.Tags, func(tagID int64, _ int) *LivestreamTagModel {
+		return &LivestreamTagModel{
 			LivestreamID: livestreamID,
 			TagID:        tagID,
-		}); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to insert livestream tag: "+err.Error())
 		}
+	})
+	// タグ追加
+	if _, err := tx.NamedExecContext(ctx, "INSERT INTO livestream_tags (livestream_id, tag_id) VALUES (:livestream_id, :tag_id)", ltModels); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to insert livestream tag: "+err.Error())
 	}
 
 	livestream, err := fillLivestreamResponse(ctx, tx, *livestreamModel)

--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -153,8 +153,10 @@ func reserveLivestreamHandler(c echo.Context) error {
 		}
 	})
 	// タグ追加
-	if _, err := tx.NamedExecContext(ctx, "INSERT INTO livestream_tags (livestream_id, tag_id) VALUES (:livestream_id, :tag_id)", ltModels); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to insert livestream tag: "+err.Error())
+	if len(ltModels) > 0 {
+		if _, err := tx.NamedExecContext(ctx, "INSERT INTO livestream_tags (livestream_id, tag_id) VALUES (:livestream_id, :tag_id)", ltModels); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to insert livestream tag: "+err.Error())
+		}
 	}
 
 	livestream, err := fillLivestreamResponse(ctx, tx, *livestreamModel)


### PR DESCRIPTION
95912

```
2023-11-27T14:22:40.366Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-27T14:22:40.366Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-27T14:22:40.366Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-27T14:22:40.366Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-27T14:22:43.697Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-27T14:22:50.616Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-27T14:22:50.616Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-27T14:23:28.622Z	info	isupipe-benchmarker	DNS水責め負荷が上昇します	{"parallelis": 3}
2023-11-27T14:23:50.618Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-27T14:23:50.632Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "satomikato1", "livestream_id": 8184, "error": "Post \"https://nakamurataro0.u.isucon.dev:443/api/livestream/8184/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:23:50.633Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "tomoyayamazaki0", "livestream_id": 7529, "error": "Post \"https://iyamamoto1.u.isucon.dev:443/api/livestream/7529/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:23:50.633Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "naoki631", "livestream_id": 7886, "error": "Post \"https://katominoru0.u.isucon.dev:443/api/livestream/7886/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:23:50.633Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "ishiiakemi0", "livestream_id": 7566, "error": "Post \"https://reisakamoto0.u.isucon.dev:443/api/livestream/7566/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:23:50.633Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "yutanakamura0", "livestream_id": 8181, "error": "Post \"https://maaya520.u.isucon.dev:443/api/livestream/8181/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:23:50.634Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "qsato1", "livestream_id": 7745, "error": "Post \"https://yukitanaka0.u.isucon.dev:443/api/livestream/7745/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:23:51.215Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-27T14:23:51.215Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-27T14:23:51.215Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-27T14:23:51.216Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-27T14:23:51.216Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 490}
```