### PR TITLE
ログ消す

### DIFF
--- a/go/livecomment_handler.go
+++ b/go/livecomment_handler.go
@@ -205,7 +205,6 @@ func postLivecommentHandler(c echo.Context) error {
 		}
 	}
 
-	c.Logger().Infof("[containsNgWord=%v] comment = %s", containsNgWord, req.Comment)
 	if containsNgWord {
 		return echo.NewHTTPError(http.StatusBadRequest, "このコメントがスパム判定されました")
 	}

--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -113,7 +113,6 @@ func reserveLivestreamHandler(c echo.Context) error {
 	}
 	for _, slot := range slots {
 		count := slot.Slot
-		c.Logger().Infof("%d ~ %d予約枠の残数 = %d\n", slot.StartAt, slot.EndAt, slot.Slot)
 		if count < 1 {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("予約期間 %d ~ %dに対して、予約区間 %d ~ %dが予約できません", termStartAt.Unix(), termEndAt.Unix(), req.StartAt, req.EndAt))
 		}

--- a/go/user_handler.go
+++ b/go/user_handler.go
@@ -108,7 +108,6 @@ func getIconHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get user icon: "+err.Error())
 	}
 
-	c.Logger().Infof("iconhash: %s header:%s", hash, c.Request().Header.Get("If-None-Match"))
 	if c.Request().Header.Get("If-None-Match") == fmt.Sprintf("\"%s\"", hash) {
 		return c.NoContent(http.StatusNotModified)
 	}


### PR DESCRIPTION
97829

```
2023-11-27T14:30:33.792Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-27T14:30:33.793Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-27T14:30:33.793Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-27T14:30:33.793Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-27T14:30:37.049Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-27T14:30:43.985Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-27T14:30:43.985Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-27T14:31:19.993Z	info	isupipe-benchmarker	DNS水責め負荷が上昇します	{"parallelis": 3}
2023-11-27T14:31:43.985Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-27T14:31:43.986Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "onakamura1", "livestream_id": 7748, "error": "Post \"https://kana200.u.isucon.dev:443/api/livestream/7748/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:31:43.987Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "asuka281", "livestream_id": 7908, "error": "Post \"https://satomiishii0.u.isucon.dev:443/api/livestream/7908/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:31:43.988Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "mituruyamamoto0", "livestream_id": 7915, "error": "Post \"https://akira250.u.isucon.dev:443/api/livestream/7915/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:31:43.988Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "yui590", "livestream_id": 8193, "error": "Post \"https://wito0.u.isucon.dev:443/api/livestream/8193/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:31:44.362Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-27T14:31:44.362Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-27T14:31:44.363Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-27T14:31:44.363Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-27T14:31:44.363Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 502}
```