### PR TITLE
タグ検索でクエリしない

### DIFF
--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -183,11 +183,7 @@ func searchLivestreamsHandler(c echo.Context) error {
 	var livestreamModels []*LivestreamModel
 	if c.QueryParam("tag") != "" {
 		// タグによる取得
-		var tagIDList []int
-		if err := tx.SelectContext(ctx, &tagIDList, "SELECT id FROM tags WHERE name = ?", keyTagName); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get tags: "+err.Error())
-		}
-
+		tagIDList := []int{int(tagByName[keyTagName].ID)}
 		query, params, err := sqlx.In("SELECT * FROM livestream_tags WHERE tag_id IN (?)", tagIDList)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to construct IN query for livestream_tags: "+err.Error())

--- a/go/tags.go
+++ b/go/tags.go
@@ -107,7 +107,7 @@ var tagsAll = map[int64]*Tag{
 }
 
 // tags.name -> tag
-var tagByName map[string]*Tag
+var tagByName = make(map[string]*Tag)
 
 func init() {
 	for _, tag := range tagsAll {

--- a/go/tags.go
+++ b/go/tags.go
@@ -105,3 +105,12 @@ var tagsAll = map[int64]*Tag{
 	102: &Tag{ID: 102, Name: "サプライズ"},
 	103: &Tag{ID: 103, Name: "椅子"},
 }
+
+// tags.name -> tag
+var tagByName map[string]*Tag
+
+func init() {
+	for _, tag := range tagsAll {
+		tagByName[tag.Name] = tag
+	}
+}


### PR DESCRIPTION
98057

```
2023-11-27T14:42:23.273Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-27T14:42:23.273Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-27T14:42:23.273Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-27T14:42:23.273Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-27T14:42:26.473Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-27T14:42:33.352Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-27T14:42:33.352Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-27T14:43:09.361Z	info	isupipe-benchmarker	DNS水責め負荷が上昇します	{"parallelis": 3}
2023-11-27T14:43:33.354Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-27T14:43:33.355Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "yuki280", "livestream_id": 7649, "error": "Post \"https://kobayashiyasuhiro1.u.isucon.dev:443/api/livestream/7649/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:43:33.355Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "kumikosuzuki2", "livestream_id": 7736, "error": "Post \"https://yamazakikyosuke0.u.isucon.dev:443/api/livestream/7736/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:43:33.355Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "csato3", "livestream_id": 7908, "error": "Post \"https://maaya520.u.isucon.dev:443/api/livestream/7908/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:43:33.355Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "ryohei260", "livestream_id": 7910, "error": "Post \"https://bhasegawa0.u.isucon.dev:443/api/livestream/7910/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:43:33.355Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "xsaito0", "livestream_id": 7748, "error": "Post \"https://ryohei000.u.isucon.dev:443/api/livestream/7748/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:43:33.356Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "myoshida0", "livestream_id": 7915, "error": "Post \"https://satomigoto0.u.isucon.dev:443/api/livestream/7915/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:43:33.356Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "msuzuki2", "livestream_id": 7571, "error": "Post \"https://kanasasaki0.u.isucon.dev:443/api/livestream/7571/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:43:33.356Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "yamadaatsushi1", "livestream_id": 8205, "error": "Post \"https://ryosuke890.u.isucon.dev:443/api/livestream/8205/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T14:43:33.814Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-27T14:43:33.814Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-27T14:43:33.814Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-27T14:43:33.814Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-27T14:43:33.814Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 500}
```