### PR TITLE
アイコンのキャッシュでsync.RWMutexを使う

### DIFF
--- a/go/icon_cache.go
+++ b/go/icon_cache.go
@@ -18,11 +18,11 @@ type IconCacheData struct {
 type IconCach map[int64]IconCacheData
 
 var iconCache = IconCach{}
-var iconCacheMutex = sync.Mutex{}
+var iconCacheMutex = sync.RWMutex{}
 
 func getIconHashByIds(ctx context.Context, db sqlx.QueryerContext, userIds []int64) (map[int64]string, error) {
 	resHashByUserId := make(map[int64]string)
-	iconCacheMutex.Lock()
+	iconCacheMutex.RLock()
 	needFetchUserIds := []int64{}
 	for _, userId := range userIds {
 		data, ok := iconCache[userId]
@@ -32,7 +32,7 @@ func getIconHashByIds(ctx context.Context, db sqlx.QueryerContext, userIds []int
 		}
 		needFetchUserIds = append(needFetchUserIds, userId)
 	}
-	iconCacheMutex.Unlock()
+	iconCacheMutex.RUnlock()
 
 	if len(needFetchUserIds) > 0 {
 		hashByUserId, err := fetchIconByIds(ctx, db, needFetchUserIds)


### PR DESCRIPTION
96030

```
2023-11-27T15:05:13.311Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-27T15:05:13.311Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-27T15:05:13.311Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-27T15:05:13.311Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-27T15:05:16.808Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-27T15:05:23.730Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-27T15:05:23.730Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-27T15:05:57.737Z	info	isupipe-benchmarker	DNS水責め負荷が上昇します	{"parallelis": 3}
2023-11-27T15:06:23.734Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-27T15:06:23.748Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "shotanakamura0", "livestream_id": 7887, "error": "Post \"https://qsaito0.u.isucon.dev:443/api/livestream/7887/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T15:06:23.748Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "chiyo150", "livestream_id": 7736, "error": "Post \"https://kobayashihanako0.u.isucon.dev:443/api/livestream/7736/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T15:06:23.748Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "taro821", "livestream_id": 7592, "error": "Post \"https://vito1.u.isucon.dev:443/api/livestream/7592/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T15:06:23.748Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "cishii1", "livestream_id": 7876, "error": "Post \"https://kobayashitsubasa1.u.isucon.dev:443/api/livestream/7876/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T15:06:23.748Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "tanakamomoko1", "livestream_id": 7901, "error": "Post \"https://xsato0.u.isucon.dev:443/api/livestream/7901/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T15:06:23.749Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "itorika0", "livestream_id": 7899, "error": "Post \"https://nishikawa0.u.isucon.dev:443/api/livestream/7899/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T15:06:24.069Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-27T15:06:24.069Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-27T15:06:24.070Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-27T15:06:24.070Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-27T15:06:24.070Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 486}
```