### PR TITLE
iconのキャッシュ秒数を伸ばす

### DIFF
--- a/go/icon_cache.go
+++ b/go/icon_cache.go
@@ -26,7 +26,7 @@ func getIconHashByIds(ctx context.Context, db sqlx.QueryerContext, userIds []int
 	needFetchUserIds := []int64{}
 	for _, userId := range userIds {
 		data, ok := iconCache[userId]
-		if ok && data.createAt.Add(time.Second).After(time.Now()) {
+		if ok && data.createAt.Add(2*time.Second).After(time.Now()) {
 			resHashByUserId[userId] = data.hash
 			continue
 		}

--- a/go/icon_cache.go
+++ b/go/icon_cache.go
@@ -26,7 +26,7 @@ func getIconHashByIds(ctx context.Context, db sqlx.QueryerContext, userIds []int
 	needFetchUserIds := []int64{}
 	for _, userId := range userIds {
 		data, ok := iconCache[userId]
-		if ok && data.createAt.Add(2*time.Second).After(time.Now()) {
+		if ok && data.createAt.Add(10*time.Second).After(time.Now()) {
 			resHashByUserId[userId] = data.hash
 			continue
 		}

--- a/go/icon_cache.go
+++ b/go/icon_cache.go
@@ -26,7 +26,7 @@ func getIconHashByIds(ctx context.Context, db sqlx.QueryerContext, userIds []int
 	needFetchUserIds := []int64{}
 	for _, userId := range userIds {
 		data, ok := iconCache[userId]
-		if ok && data.createAt.Add(10*time.Second).After(time.Now()) {
+		if ok && data.createAt.Add(2*time.Second).After(time.Now()) {
 			resHashByUserId[userId] = data.hash
 			continue
 		}

--- a/go/main.go
+++ b/go/main.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
@@ -135,9 +134,6 @@ func initializeHandler(c echo.Context) error {
 		c.Logger().Warnf("init.sh failed with err=%s", string(out))
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to initialize: "+err.Error())
 	}
-
-	// iconのキャッシュがexpireするのを待つ
-	time.Sleep(10 * time.Second)
 
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 	return c.JSON(http.StatusOK, InitializeResponse{

--- a/go/main.go
+++ b/go/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
@@ -134,6 +135,9 @@ func initializeHandler(c echo.Context) error {
 		c.Logger().Warnf("init.sh failed with err=%s", string(out))
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to initialize: "+err.Error())
 	}
+
+	// iconのキャッシュがexpireするのを待つ
+	time.Sleep(10 * time.Second)
 
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 	return c.JSON(http.StatusOK, InitializeResponse{


### PR DESCRIPTION
99333

```
2023-11-27T15:44:20.744Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-27T15:44:20.744Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-27T15:44:20.744Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-27T15:44:20.744Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-27T15:44:24.013Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-27T15:44:30.912Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-27T15:44:30.912Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-27T15:45:08.919Z	info	isupipe-benchmarker	DNS水責め負荷が上昇します	{"parallelis": 3}
2023-11-27T15:45:30.915Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-27T15:45:30.916Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "tanakaasuka0", "livestream_id": 7858, "error": "Post \"https://okobayashi0.u.isucon.dev:443/api/livestream/7858/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T15:45:30.916Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "satomikato1", "livestream_id": 8181, "error": "Post \"https://nishimurayoko0.u.isucon.dev:443/api/livestream/8181/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T15:45:30.916Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "yuki870", "livestream_id": 7624, "error": "Post \"https://vkobayashi0.u.isucon.dev:443/api/livestream/7624/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T15:45:30.917Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "taro470", "livestream_id": 7719, "error": "Post \"https://ghasegawa0.u.isucon.dev:443/api/livestream/7719/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T15:45:30.917Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "yoko880", "livestream_id": 8198, "error": "Post \"https://moriyosuke0.u.isucon.dev:443/api/livestream/8198/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T15:45:30.917Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "tanakamomoko1", "livestream_id": 8194, "error": "Post \"https://yoichitakahashi0.u.isucon.dev:443/api/livestream/8194/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T15:45:30.918Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "watanabekyosuke2", "livestream_id": 7735, "error": "Post \"https://yasuhirofujiwara0.u.isucon.dev:443/api/livestream/7735/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T15:45:30.918Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "naokisato2", "livestream_id": 7890, "error": "Post \"https://yamadakenichi0.u.isucon.dev:443/api/livestream/7890/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T15:45:31.598Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-27T15:45:31.598Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-27T15:45:31.598Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-27T15:45:31.598Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-27T15:45:31.599Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 510}
```