### PR TITLE
NGワードのクエリの条件を削る

### DIFF
--- a/go/livecomment_handler.go
+++ b/go/livecomment_handler.go
@@ -195,7 +195,7 @@ func postLivecommentHandler(c echo.Context) error {
 	// チップを投げない人だけスパム判定しておく
 	if req.Tip == 0 {
 		var ngwordStrs []string
-		if err := tx.SelectContext(ctx, &ngwordStrs, "SELECT word FROM ng_words WHERE user_id = ? AND livestream_id = ?", livestreamModel.UserID, livestreamModel.ID); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		if err := tx.SelectContext(ctx, &ngwordStrs, "SELECT word FROM ng_words WHERE livestream_id = ?", livestreamModel.ID); err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get NG words: "+err.Error())
 		}
 		containsNgWord := false


### PR DESCRIPTION
98048

```
2023-11-27T17:31:12.489Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-27T17:31:12.489Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-27T17:31:12.489Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-27T17:31:12.489Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-27T17:31:14.965Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-27T17:31:21.822Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-27T17:31:21.823Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-27T17:31:59.828Z	info	isupipe-benchmarker	DNS水責め負荷が上昇します	{"parallelis": 3}
2023-11-27T17:32:21.839Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-27T17:32:21.849Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "vnakajima0", "livestream_id": 7889, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:32:21.850Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "maikobayashi1", "livestream_id": 8189, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:32:21.850Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "sayuri170", "livestream_id": 7906, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:32:21.850Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "chiyosato1", "livestream_id": 7624, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:32:21.850Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "satomikato1", "livestream_id": 7909, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:32:21.851Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "manabusato2", "livestream_id": 7644, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:32:22.534Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-27T17:32:22.534Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-27T17:32:22.534Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-27T17:32:22.535Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-27T17:32:22.535Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 498}
```