### PR TITLE
使ってないlivestreamsがあるやん

### DIFF
--- a/go/stats_handler.go
+++ b/go/stats_handler.go
@@ -217,11 +217,6 @@ func getLivestreamStatisticsHandler(c echo.Context) error {
 		}
 	}
 
-	var livestreams []*LivestreamModel
-	if err := tx.SelectContext(ctx, &livestreams, "SELECT * FROM livestreams"); err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get livestreams: "+err.Error())
-	}
-
 	// ランク算出
 	var rank int64
 	{


### PR DESCRIPTION
98711

```
2023-11-27T17:36:51.153Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-27T17:36:51.153Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-27T17:36:51.153Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-27T17:36:51.153Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-27T17:36:54.319Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-27T17:37:01.161Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-27T17:37:01.161Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-27T17:37:39.168Z	info	isupipe-benchmarker	DNS水責め負荷が上昇します	{"parallelis": 3}
2023-11-27T17:38:01.163Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-27T17:38:01.184Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "osamufujita0", "livestream_id": 7741, "error": "Post \"https://bhasegawa0.u.isucon.dev:443/api/livestream/7741/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:38:01.184Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "reiogawa1", "livestream_id": 7622, "error": "Post \"https://endoyui0.u.isucon.dev:443/api/livestream/7622/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:38:01.184Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "maikobayashi1", "livestream_id": 8209, "error": "Post \"https://nanamimaeda1.u.isucon.dev:443/api/livestream/8209/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:38:01.184Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "chiyo890", "livestream_id": 8213, "error": "Post \"https://sotaro910.u.isucon.dev:443/api/livestream/8213/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:38:01.185Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "lsato2", "livestream_id": 7914, "error": "Post \"https://hiroshiyoshida1.u.isucon.dev:443/api/livestream/7914/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:38:01.898Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-27T17:38:01.898Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-27T17:38:01.898Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-27T17:38:01.898Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-27T17:38:01.898Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 499}
```