### PR TITLE
ロック獲得する時間を短くしたい

### DIFF
--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -168,7 +168,7 @@ func reserveLivestreamHandler(c echo.Context) error {
 		}
 	}
 
-	livestream, err := fillLivestreamResponse(ctx, tx, *livestreamModel)
+	livestream, err := fillLivestreamResponse(ctx, tx2, *livestreamModel)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to fill livestream: "+err.Error())
 	}

--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -117,6 +117,10 @@ func reserveLivestreamHandler(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("予約期間 %d ~ %dに対して、予約区間 %d ~ %dが予約できません", termStartAt.Unix(), termEndAt.Unix(), req.StartAt, req.EndAt))
 		}
 	}
+	// ロックを解放するためにここでいったんcommitしておく
+	if err := tx.Commit(); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to commit transaction: "+err.Error())
+	}
 
 	var (
 		livestreamModel = &LivestreamModel{
@@ -130,11 +134,17 @@ func reserveLivestreamHandler(c echo.Context) error {
 		}
 	)
 
-	if _, err := tx.ExecContext(ctx, "UPDATE reservation_slots SET slot = slot - 1 WHERE start_at >= ? AND end_at <= ?", req.StartAt, req.EndAt); err != nil {
+	tx2, err := dbConn.BeginTxx(ctx, nil)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to begin transaction: "+err.Error())
+	}
+	defer tx2.Rollback()
+
+	if _, err := tx2.ExecContext(ctx, "UPDATE reservation_slots SET slot = slot - 1 WHERE start_at >= ? AND end_at <= ?", req.StartAt, req.EndAt); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to update reservation_slot: "+err.Error())
 	}
 
-	rs, err := tx.NamedExecContext(ctx, "INSERT INTO livestreams (user_id, title, description, playlist_url, thumbnail_url, start_at, end_at) VALUES(:user_id, :title, :description, :playlist_url, :thumbnail_url, :start_at, :end_at)", livestreamModel)
+	rs, err := tx2.NamedExecContext(ctx, "INSERT INTO livestreams (user_id, title, description, playlist_url, thumbnail_url, start_at, end_at) VALUES(:user_id, :title, :description, :playlist_url, :thumbnail_url, :start_at, :end_at)", livestreamModel)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to insert livestream: "+err.Error())
 	}
@@ -153,7 +163,7 @@ func reserveLivestreamHandler(c echo.Context) error {
 	})
 	// タグ追加
 	if len(ltModels) > 0 {
-		if _, err := tx.NamedExecContext(ctx, "INSERT INTO livestream_tags (livestream_id, tag_id) VALUES (:livestream_id, :tag_id)", ltModels); err != nil {
+		if _, err := tx2.NamedExecContext(ctx, "INSERT INTO livestream_tags (livestream_id, tag_id) VALUES (:livestream_id, :tag_id)", ltModels); err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to insert livestream tag: "+err.Error())
 		}
 	}
@@ -163,7 +173,7 @@ func reserveLivestreamHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to fill livestream: "+err.Error())
 	}
 
-	if err := tx.Commit(); err != nil {
+	if err := tx2.Commit(); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to commit: "+err.Error())
 	}
 


### PR DESCRIPTION
99383

```
2023-11-27T17:46:29.605Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-27T17:46:29.605Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-27T17:46:29.605Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-27T17:46:29.605Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-27T17:46:32.682Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-27T17:46:39.537Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-27T17:46:39.537Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-27T17:47:17.547Z	info	isupipe-benchmarker	DNS水責め負荷が上昇します	{"parallelis": 3}
2023-11-27T17:47:39.541Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "shota370", "livestream_id": 8181, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:47:39.541Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-27T17:47:39.560Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "sito1", "livestream_id": 7550, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:47:39.561Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "jun180", "livestream_id": 8191, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:47:39.562Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "maedatomoya0", "livestream_id": 7746, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:47:39.565Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "yuta180", "livestream_id": 7654, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:47:39.565Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "yasuhiroabe0", "livestream_id": 7902, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:47:39.565Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "yoichiyamashita1", "livestream_id": 7874, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T17:47:40.184Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-27T17:47:40.184Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-27T17:47:40.184Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-27T17:47:40.184Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-27T17:47:40.184Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 505}
```