### PR TITLE
古いスパムの削除はreq.NGWordに対してだけやればよい

### DIFF
--- a/go/livecomment_handler.go
+++ b/go/livecomment_handler.go
@@ -370,25 +370,13 @@ func moderateHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get last inserted NG word id: "+err.Error())
 	}
 
-	livecomments := []*LivecommentModel{}
-	if err := tx.SelectContext(ctx, &livecomments, "SELECT id, comment FROM livecomments WHERE livestream_id = ?", livestreamID); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to select livecomments: "+err.Error())
-	}
-	var willBeDeletedLiveCommentIds []int64
-	for _, livecomment := range livecomments {
-		if strings.Contains(livecomment.Comment, req.NGWord) {
-			willBeDeletedLiveCommentIds = append(willBeDeletedLiveCommentIds, livecomment.ID)
-		}
-	}
-
-	if len(willBeDeletedLiveCommentIds) > 0 {
-		query, args, err := sqlx.In("DELETE FROM livecomments WHERE id IN (?)", willBeDeletedLiveCommentIds)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to construct IN query: "+err.Error())
-		}
-		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete old livecomments that hit spams: "+err.Error())
-		}
+	query := `
+	DELETE FROM livecomments
+	WHERE livestream_id = ? AND
+	comment LIKE CONCAT('%', ?, '%');
+	`
+	if _, err := tx.ExecContext(ctx, query, livestreamID, req.NGWord); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete old livecomments that hit spams: "+err.Error())
 	}
 
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
101881

```
2023-11-27T18:11:21.608Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-27T18:11:21.608Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-27T18:11:21.608Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-27T18:11:21.608Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-27T18:11:24.660Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-27T18:11:31.477Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-27T18:11:31.477Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-27T18:12:07.484Z	info	isupipe-benchmarker	DNS水責め負荷が上昇します	{"parallelis": 3}
2023-11-27T18:12:31.493Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-27T18:12:31.511Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "minoruyoshida1", "livestream_id": 8193, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T18:12:31.514Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "shimizusotaro1", "livestream_id": 8203, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T18:12:31.514Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "etakahashi3", "livestream_id": 8204, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T18:12:31.554Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "ryosukesuzuki0", "livestream_id": 7678, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T18:12:31.556Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "cinoue1", "livestream_id": 7756, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T18:12:31.556Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "ttakahashi0", "livestream_id": 7559, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T18:12:31.557Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "lsato2", "livestream_id": 7761, "error": "ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T18:12:32.238Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-27T18:12:32.238Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-27T18:12:32.238Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-27T18:12:32.238Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-27T18:12:32.239Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 514}
```