### PR TITLE
DNS TTL 60

### DIFF
--- a/go/user_handler.go
+++ b/go/user_handler.go
@@ -261,7 +261,7 @@ func registerHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to insert user theme: "+err.Error())
 	}
 
-	if out, err := exec.Command("pdnsutil", "add-record", "u.isucon.dev", req.Name, "A", "0", powerDNSSubdomainAddress).CombinedOutput(); err != nil {
+	if out, err := exec.Command("pdnsutil", "add-record", "u.isucon.dev", req.Name, "A", "60", powerDNSSubdomainAddress).CombinedOutput(); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, string(out)+": "+err.Error())
 	}
 


### PR DESCRIPTION
103267

```
2023-11-27T18:25:18.482Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-27T18:25:18.482Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-27T18:25:18.482Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-27T18:25:18.482Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-27T18:25:21.586Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-27T18:25:28.380Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-27T18:25:28.380Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-27T18:26:28.381Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-27T18:26:28.381Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "mikako460", "livestream_id": 8220, "error": "Post \"https://tsubasa620.u.isucon.dev:443/api/livestream/8220/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T18:26:28.382Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "hayashitomoya0", "livestream_id": 8216, "error": "Post \"https://fukudamikako0.u.isucon.dev:443/api/livestream/8216/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T18:26:28.382Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "zkato0", "livestream_id": 7615, "error": "Post \"https://yukitanaka0.u.isucon.dev:443/api/livestream/7615/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T18:26:28.382Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "iyamashita0", "livestream_id": 7777, "error": "Post \"https://tsuzuki1.u.isucon.dev:443/api/livestream/7777/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T18:26:28.382Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "wsato1", "livestream_id": 7545, "error": "Post \"https://atsushi410.u.isucon.dev:443/api/livestream/7545/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T18:26:28.382Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "asukanakagawa0", "livestream_id": 7932, "error": "Post \"https://mikimatsuda0.u.isucon.dev:443/api/livestream/7932/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T18:26:28.382Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "osamufujita0", "livestream_id": 7608, "error": "Post \"https://reisakamoto0.u.isucon.dev:443/api/livestream/7608/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-27T18:26:28.655Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-27T18:26:28.655Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-27T18:26:28.655Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-27T18:26:28.655Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-27T18:26:28.655Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 533}
```