### PR TITLE
アイコン画像をnginxから配信する

### DIFF
--- a/conf/etc/nginx/sites-enabled/isupipe.conf
+++ b/conf/etc/nginx/sites-enabled/isupipe.conf
@@ -1,6 +1,6 @@
 upstream origin {
   server isucon1:8080 weight=12;
-  server 127.0.0.1:8080 weight=4;
+  server 127.0.0.1:8080 weight=1;
 }
 
 server {

--- a/conf/etc/nginx/sites-enabled/isupipe.conf
+++ b/conf/etc/nginx/sites-enabled/isupipe.conf
@@ -69,6 +69,11 @@ server {
   location /_icon {
     internal;
 
+    # https://ryuichi1208.hateblo.jp/entry/2020/04/03/215956
+    open_file_cache max=200000 inactive=20s;
+    open_file_cache_valid 30s;
+    open_file_cache_min_uses 2;
+    open_file_cache_errors on;
     alias /home/isucon/webapp/img/;
   }
 }

--- a/conf/etc/nginx/sites-enabled/isupipe.conf
+++ b/conf/etc/nginx/sites-enabled/isupipe.conf
@@ -1,5 +1,5 @@
 upstream origin {
-  server isucon1:8080 weight=7;
+  server isucon1:8080 weight=12;
   server 127.0.0.1:8080 weight=4;
 }
 

--- a/conf/etc/nginx/sites-enabled/isupipe.conf
+++ b/conf/etc/nginx/sites-enabled/isupipe.conf
@@ -74,6 +74,7 @@ server {
     open_file_cache_valid 30s;
     open_file_cache_min_uses 2;
     open_file_cache_errors on;
+    add_header Cache-Control "public, max-age=86400";
     alias /home/isucon/webapp/img/;
   }
 }

--- a/conf/etc/nginx/sites-enabled/isupipe.conf
+++ b/conf/etc/nginx/sites-enabled/isupipe.conf
@@ -67,8 +67,7 @@ server {
   }
 
   location /_icon {
-    # TODO
-    # internal;
+    internal;
 
     alias /home/isucon/webapp/img/;
   }

--- a/conf/etc/nginx/sites-enabled/isupipe.conf
+++ b/conf/etc/nginx/sites-enabled/isupipe.conf
@@ -55,4 +55,21 @@ server {
     proxy_set_header Host $host;
     proxy_pass http://origin;
   }
+
+  location = /api/icon {
+    proxy_set_header Host $host;
+    proxy_pass http://127.0.0.1:8080;
+  }
+
+  location ~ /api/user/.+/icon {
+    proxy_set_header Host $host;
+    proxy_pass http://127.0.0.1:8080;
+  }
+
+  location /_icon {
+    # TODO
+    # internal;
+
+    alias /home/isucon/webapp/img/;
+  }
 }

--- a/go/user_handler.go
+++ b/go/user_handler.go
@@ -113,7 +113,11 @@ func getIconHandler(c echo.Context) error {
 		return c.NoContent(http.StatusNotModified)
 	}
 
-	c.Response().Header().Set("X-Accel-Redirect", "/_icon/"+hash+".jpg")
+	filename := hash+".jpg"
+	if hash == fallbackImageHash {
+		filename = "NoImage.jpg"
+	}
+	c.Response().Header().Set("X-Accel-Redirect", "/_icon/"+filename)
 	return c.NoContent(http.StatusOK)
 }
 

--- a/go/user_handler.go
+++ b/go/user_handler.go
@@ -146,7 +146,7 @@ func postIconHandler(c echo.Context) error {
 	defer tx.Rollback()
 
 	iconHash := fmt.Sprintf("%x", sha256.Sum256(req.Image))
-	rs, err := tx.ExecContext(ctx, "INSERT INTO icons (user_id, image, hash) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE image = ?, hash = ?", userID, req.Image, iconHash[:], req.Image, iconHash[:])
+	rs, err := tx.ExecContext(ctx, "INSERT INTO icons (user_id, image, hash) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE image = ?, hash = ?", userID, req.Image, iconHash[:], []byte{}, iconHash[:])
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to insert new user icon: "+err.Error())
 	}

--- a/go/user_handler.go
+++ b/go/user_handler.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"os/exec"
 	"time"
 
@@ -161,6 +162,10 @@ func postIconHandler(c echo.Context) error {
 
 	if err := tx.Commit(); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to commit: "+err.Error())
+	}
+
+	if err := os.WriteFile("/home/isucon/webapp/img/"+iconHash+".jpg", req.Image, 0644); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to write file: "+err.Error())
 	}
 
 	return c.JSON(http.StatusCreated, &PostIconResponse{

--- a/go/user_handler.go
+++ b/go/user_handler.go
@@ -146,7 +146,7 @@ func postIconHandler(c echo.Context) error {
 	defer tx.Rollback()
 
 	iconHash := fmt.Sprintf("%x", sha256.Sum256(req.Image))
-	rs, err := tx.ExecContext(ctx, "INSERT INTO icons (user_id, image, hash) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE image = ?, hash = ?", userID, req.Image, iconHash[:], []byte{}, iconHash[:])
+	rs, err := tx.ExecContext(ctx, "INSERT INTO icons (user_id, image, hash) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE image = ?, hash = ?", userID, []byte{}, iconHash[:], []byte{}, iconHash[:])
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to insert new user icon: "+err.Error())
 	}

--- a/go/user_handler.go
+++ b/go/user_handler.go
@@ -113,16 +113,8 @@ func getIconHandler(c echo.Context) error {
 		return c.NoContent(http.StatusNotModified)
 	}
 
-	var image []byte
-	if err := tx.GetContext(ctx, &image, "SELECT image FROM icons WHERE user_id = ?", user.ID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return c.File(fallbackImage)
-		} else {
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get user icon: "+err.Error())
-		}
-	}
-
-	return c.Blob(http.StatusOK, "image/jpeg", image)
+	c.Response().Header().Set("X-Accel-Redirect", "/_icon/"+hash+".jpg")
+	return c.NoContent(http.StatusOK)
 }
 
 func postIconHandler(c echo.Context) error {

--- a/img/.gitignore
+++ b/img/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!NoImage.jpg


### PR DESCRIPTION
- isucon3でアイコンを受ける
- `X-Accel-Redirect` レスポンスヘッダを使って画像をnginxから配信する
  - [S3のファイルをX-Accel-Redirectで配信する - Money Forward Developers Blog](https://moneyforward-dev.jp/entry/2021/01/13/s3-x-accel-redirect/)

102247

```
2023-11-28T04:29:53.484Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-28T04:29:53.484Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-28T04:29:53.484Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-28T04:29:53.484Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-28T04:29:56.711Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-28T04:30:03.552Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-28T04:30:03.552Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-28T04:31:03.553Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-28T04:31:03.554Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "hidekiokada1", "livestream_id": 7922, "error": "Post \"https://inouenaoki1.u.isucon.dev:443/api/livestream/7922/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T04:31:03.557Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "itojun1", "livestream_id": 8215, "error": "Post \"https://watanabemikako0.u.isucon.dev:443/api/livestream/8215/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T04:31:03.557Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "oyamamoto0", "livestream_id": 7656, "error": "Post \"https://nakamurataro0.u.isucon.dev:443/api/livestream/7656/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T04:31:03.558Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "mai400", "livestream_id": 8206, "error": "Post \"https://murakamiyoko0.u.isucon.dev:443/api/livestream/8206/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T04:31:03.558Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "skimura0", "livestream_id": 7758, "error": "Post \"https://xsato0.u.isucon.dev:443/api/livestream/7758/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T04:31:04.392Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-28T04:31:04.392Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-28T04:31:04.392Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-28T04:31:04.392Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-28T04:31:04.393Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 513}
```