### PR TITLE
予約可能かどうか見るときにCOUNTだけ見る

### DIFF
--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -105,7 +105,7 @@ func reserveLivestreamHandler(c echo.Context) error {
 	}
 
 	numResevedSlots := (req.EndAt - req.StartAt) / 3600
-	res, err := tx.ExecContext(ctx, "UPDATE reservation_slots SET slot = slot - 1 WHERE start_at >= ? AND end_at <= ?", req.StartAt, req.EndAt)
+	res, err := tx.ExecContext(ctx, "UPDATE reservation_slots SET slot = slot - 1 WHERE start_at >= ? AND end_at <= ? AND slot > 0", req.StartAt, req.EndAt)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to update reservation_slot: "+err.Error())
 	}

--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -111,7 +111,7 @@ func reserveLivestreamHandler(c echo.Context) error {
 		c.Logger().Warnf("予約枠一覧取得でエラー発生: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get reservation_slots: "+err.Error())
 	}
-	if numEmptySlot > 1 {
+	if numEmptySlot > 0 {
 		return echo.NewHTTPError(http.StatusBadRequest, "予約できません")
 	}
 	// ロックを解放するためにここでいったんcommitしておく

--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -106,16 +106,13 @@ func reserveLivestreamHandler(c echo.Context) error {
 
 	// 予約枠をみて、予約が可能か調べる
 	// NOTE: 並列な予約のoverbooking防止にFOR UPDATEが必要
-	var slots []*ReservationSlotModel
-	if err := tx.SelectContext(ctx, &slots, "SELECT * FROM reservation_slots WHERE start_at >= ? AND end_at <= ? FOR UPDATE", req.StartAt, req.EndAt); err != nil {
+	var numEmptySlot int
+	if err := tx.GetContext(ctx, &numEmptySlot, "SELECT COUNT(*) FROM reservation_slots WHERE start_at >= ? AND end_at <= ? AND slot = 0 FOR UPDATE", req.StartAt, req.EndAt); err != nil {
 		c.Logger().Warnf("予約枠一覧取得でエラー発生: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get reservation_slots: "+err.Error())
 	}
-	for _, slot := range slots {
-		count := slot.Slot
-		if count < 1 {
-			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("予約期間 %d ~ %dに対して、予約区間 %d ~ %dが予約できません", termStartAt.Unix(), termEndAt.Unix(), req.StartAt, req.EndAt))
-		}
+	if numEmptySlot > 1 {
+		return echo.NewHTTPError(http.StatusBadRequest, "予約できません")
 	}
 	// ロックを解放するためにここでいったんcommitしておく
 	if err := tx.Commit(); err != nil {

--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -105,7 +105,7 @@ func reserveLivestreamHandler(c echo.Context) error {
 	}
 
 	numResevedSlots := (req.EndAt - req.StartAt) / 3600
-	res, err := tx.ExecContext(ctx, "UPDATE reservation_slots SET slot = slot - 1 WHERE start_at >= ? AND end_at <= ? AND slot > 0", req.StartAt, req.EndAt)
+	res, err := tx.ExecContext(ctx, "UPDATE reservation_slots SET slot = slot - 1 WHERE start_at >= ? AND end_at <= ?", req.StartAt, req.EndAt)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to update reservation_slot: "+err.Error())
 	}

--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -107,7 +107,7 @@ func reserveLivestreamHandler(c echo.Context) error {
 	// 予約枠をみて、予約が可能か調べる
 	// NOTE: 並列な予約のoverbooking防止にFOR UPDATEが必要
 	var numEmptySlot int
-	if err := tx.GetContext(ctx, &numEmptySlot, "SELECT COUNT(*) FROM reservation_slots WHERE start_at >= ? AND end_at <= ? AND slot = 0 FOR UPDATE", req.StartAt, req.EndAt); err != nil {
+	if err := tx.GetContext(ctx, &numEmptySlot, "SELECT COUNT(*) FROM reservation_slots WHERE (start_at BETWEEN ? AND ?) AND end_at <= ? AND slot = 0 FOR UPDATE", req.StartAt, req.EndAt, req.EndAt); err != nil {
 		c.Logger().Warnf("予約枠一覧取得でエラー発生: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get reservation_slots: "+err.Error())
 	}

--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -104,17 +104,18 @@ func reserveLivestreamHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "bad reservation time range")
 	}
 
-	numResevedSlots := (req.EndAt - req.StartAt) / 3600
-	res, err := tx.ExecContext(ctx, "UPDATE reservation_slots SET slot = slot - 1 WHERE start_at >= ? AND end_at <= ?", req.StartAt, req.EndAt)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to update reservation_slot: "+err.Error())
+	// 予約枠をみて、予約が可能か調べる
+	// NOTE: 並列な予約のoverbooking防止にFOR UPDATEが必要
+	var slots []*ReservationSlotModel
+	if err := tx.SelectContext(ctx, &slots, "SELECT * FROM reservation_slots WHERE start_at >= ? AND end_at <= ? FOR UPDATE", req.StartAt, req.EndAt); err != nil {
+		c.Logger().Warnf("予約枠一覧取得でエラー発生: %+v", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get reservation_slots: "+err.Error())
 	}
-	affected, err := res.RowsAffected()
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get rows affected: "+err.Error())
-	}
-	if affected != numResevedSlots {
-		return echo.NewHTTPError(http.StatusBadRequest, "予約できません")
+	for _, slot := range slots {
+		count := slot.Slot
+		if count < 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("予約期間 %d ~ %dに対して、予約区間 %d ~ %dが予約できません", termStartAt.Unix(), termEndAt.Unix(), req.StartAt, req.EndAt))
+		}
 	}
 	// ロックを解放するためにここでいったんcommitしておく
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
153592

```
2023-11-28T11:45:07.949Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-28T11:45:07.949Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-28T11:45:07.949Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-28T11:45:07.949Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-28T11:45:11.589Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-28T11:45:18.341Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-28T11:45:18.341Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-28T11:45:58.348Z	info	isupipe-benchmarker	DNS水責め負荷が上昇します	{"parallelis": 3}
2023-11-28T11:46:18.341Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-28T11:46:18.342Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "xkobayashi1", "livestream_id": 8096, "error": "Post \"https://kanasasaki0.u.isucon.dev:443/api/livestream/8096/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T11:46:18.343Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "matsudaminoru0", "livestream_id": 7867, "error": "Post \"https://satomi500.u.isucon.dev:443/api/livestream/7867/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T11:46:18.343Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "katoryosuke0", "livestream_id": 8447, "error": "Post \"https://jshimizu0.u.isucon.dev:443/api/livestream/8447/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T11:46:18.343Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "taro470", "livestream_id": 8446, "error": "Post \"https://hyoshida0.u.isucon.dev:443/api/livestream/8446/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T11:46:18.343Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "takumatanaka2", "livestream_id": 8444, "error": "Post \"https://pkobayashi0.u.isucon.dev:443/api/livestream/8444/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T11:46:18.343Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "hkato0", "livestream_id": 8452, "error": "Post \"https://yosuke060.u.isucon.dev:443/api/livestream/8452/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T11:46:19.317Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-28T11:46:19.317Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-28T11:46:19.317Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-28T11:46:19.318Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-28T11:46:19.318Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 797}
```