### PR TITLE
こっちも

### DIFF
--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -137,7 +137,7 @@ func reserveLivestreamHandler(c echo.Context) error {
 	}
 	defer tx2.Rollback()
 
-	if _, err := tx2.ExecContext(ctx, "UPDATE reservation_slots SET slot = slot - 1 WHERE start_at >= ? AND end_at <= ?", req.StartAt, req.EndAt); err != nil {
+	if _, err := tx2.ExecContext(ctx, "UPDATE reservation_slots SET slot = slot - 1 WHERE (start_at BETWEEN ? AND ?) AND end_at <= ?", req.StartAt, req.EndAt, req.EndAt); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to update reservation_slot: "+err.Error())
 	}
 


### PR DESCRIPTION
168908

```
2023-11-28T12:00:01.850Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-28T12:00:01.850Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-28T12:00:01.850Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-28T12:00:01.850Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-28T12:00:05.462Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-28T12:00:11.947Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-28T12:00:11.947Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-28T12:01:11.948Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-28T12:01:11.948Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "bhashimoto1", "livestream_id": 7634, "error": "Post \"https://atsushi410.u.isucon.dev:443/api/livestream/7634/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T12:01:11.949Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "osamu540", "livestream_id": 7924, "error": "Post \"https://hyoshida0.u.isucon.dev:443/api/livestream/7924/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T12:01:11.949Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "sabe1", "livestream_id": 7919, "error": "Post \"https://kazuyasato0.u.isucon.dev:443/api/livestream/7919/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T12:01:11.949Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "manabu890", "livestream_id": 7930, "error": "Post \"https://yamamotomai0.u.isucon.dev:443/api/livestream/7930/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T12:01:11.949Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "hanako840", "livestream_id": 7626, "error": "Post \"https://hanako600.u.isucon.dev:443/api/livestream/7626/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T12:01:12.943Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-28T12:01:12.943Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-28T12:01:12.943Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-28T12:01:12.943Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-28T12:01:12.946Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 862}
```