### PR TITLE
Livestream tags foreign key

### DIFF
--- a/sql/initdb.d/10_schema.sql
+++ b/sql/initdb.d/10_schema.sql
@@ -64,7 +64,7 @@ CREATE TABLE `livestream_tags` (
   `tag_id` BIGINT NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 ALTER TABLE `livestream_tags` ADD KEY `livestream_tags_livestream_id` (`livestream_id`);
-ALTER TABLE `livestream_tags` ADD KEY `livestream_tags_tag_id`;
+ALTER TABLE `livestream_tags` ADD KEY `livestream_tags_tag_id` (`tag_id`);
 
 -- ライブ配信視聴履歴
 CREATE TABLE `livestream_viewers_history` (

--- a/sql/initdb.d/10_schema.sql
+++ b/sql/initdb.d/10_schema.sql
@@ -64,6 +64,7 @@ CREATE TABLE `livestream_tags` (
   `tag_id` BIGINT NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 ALTER TABLE `livestream_tags` ADD FOREIGN KEY `livestream_tags_livestream_id` (`livestream_id`) REFERENCES `livestreams` (`id`);
+ALTER TABLE `livestream_tags` ADD FOREIGN KEY `livestream_tags_tag_id` (`tag_id`) REFERENCES `tags` (`id`);
 
 -- ライブ配信視聴履歴
 CREATE TABLE `livestream_viewers_history` (

--- a/sql/initdb.d/10_schema.sql
+++ b/sql/initdb.d/10_schema.sql
@@ -63,8 +63,8 @@ CREATE TABLE `livestream_tags` (
   `livestream_id` BIGINT NOT NULL,
   `tag_id` BIGINT NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-ALTER TABLE `livestream_tags` ADD FOREIGN KEY `livestream_tags_livestream_id` (`livestream_id`) REFERENCES `livestreams` (`id`);
-ALTER TABLE `livestream_tags` ADD FOREIGN KEY `livestream_tags_tag_id` (`tag_id`) REFERENCES `tags` (`id`);
+ALTER TABLE `livestream_tags` ADD KEY `livestream_tags_livestream_id` (`livestream_id`);
+ALTER TABLE `livestream_tags` ADD KEY `livestream_tags_tag_id`;
 
 -- ライブ配信視聴履歴
 CREATE TABLE `livestream_viewers_history` (

--- a/sql/initdb.d/10_schema.sql
+++ b/sql/initdb.d/10_schema.sql
@@ -123,4 +123,4 @@ CREATE TABLE `reactions` (
   `created_at` BIGINT NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 ALTER TABLE `reactions` ADD INDEX `reactions_user_id` (`user_id`);
-ALTER TABLE `reactions` ADD INDEX `reactions_livestream_id` (`livestream_id`);
+ALTER TABLE `reactions` ADD INDEX `reactions_livestream_id_created_at_desc` (`livestream_id`, `created_at` DESC);


### PR DESCRIPTION
168386

```
2023-11-28T13:34:03.548Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-28T13:34:03.548Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-28T13:34:03.548Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-28T13:34:03.548Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-28T13:34:07.294Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-28T13:34:13.785Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-28T13:34:13.785Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-28T13:35:13.786Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-28T13:35:13.786Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "osato3", "livestream_id": 7937, "error": "Post \"https://kana200.u.isucon.dev:443/api/livestream/7937/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T13:35:13.788Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "miurakazuya0", "livestream_id": 7955, "error": "Post \"https://shoheiinoue0.u.isucon.dev:443/api/livestream/7955/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T13:35:13.788Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "yoichi650", "livestream_id": 7924, "error": "Post \"https://yukitanaka0.u.isucon.dev:443/api/livestream/7924/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T13:35:13.788Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "shota370", "livestream_id": 7954, "error": "Post \"https://sotaronakamura0.u.isucon.dev:443/api/livestream/7954/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T13:35:13.788Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "maedakazuya1", "livestream_id": 7624, "error": "Post \"https://fujitajun0.u.isucon.dev:443/api/livestream/7624/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T13:35:13.788Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "kenichiyoshida0", "livestream_id": 7649, "error": "Post \"https://utakahashi0.u.isucon.dev:443/api/livestream/7649/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T13:35:14.749Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-28T13:35:14.749Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-28T13:35:14.749Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-28T13:35:14.749Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-28T13:35:14.752Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 852}
```