### PR TITLE
LivestreamModelをキャッシュ

### DIFF
--- a/go/livestream_cache.go
+++ b/go/livestream_cache.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-const LivestreamCacheTTL = 20 * time.Second
+const LivestreamCacheTTL = 10 * time.Second
 
 type LivestreamCacheData struct {
 	livestream *LivestreamModel

--- a/go/livestream_cache.go
+++ b/go/livestream_cache.go
@@ -10,7 +10,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-const LivestreamCacheTTL = 30 * time.Second
+const LivestreamCacheTTL = 10 * time.Second
 
 var ErrLivestreamNotFound = errors.New("livestream not found")
 

--- a/go/livestream_cache.go
+++ b/go/livestream_cache.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -10,6 +11,8 @@ import (
 )
 
 const LivestreamCacheTTL = 10 * time.Second
+
+var ErrLivestreamNotFound = errors.New("livestream not found")
 
 type LivestreamCacheData struct {
 	livestream *LivestreamModel
@@ -80,7 +83,7 @@ func fetchLivestream(ctx context.Context, tx sqlx.QueryerContext, id int64) (*Li
 	}
 	user, ok := userById[id]
 	if !ok {
-		return nil, fmt.Errorf("livestream %d not found", id)
+		return nil, ErrLivestreamNotFound
 	}
 	return user, nil
 }

--- a/go/livestream_cache.go
+++ b/go/livestream_cache.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-const LivestreamCacheTTL = 10 * time.Second
+const LivestreamCacheTTL = 20 * time.Second
 
 type LivestreamCacheData struct {
 	livestream *LivestreamModel

--- a/go/livestream_cache.go
+++ b/go/livestream_cache.go
@@ -10,7 +10,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-const LivestreamCacheTTL = 10 * time.Second
+const LivestreamCacheTTL = 30 * time.Second
 
 var ErrLivestreamNotFound = errors.New("livestream not found")
 

--- a/go/livestream_cache.go
+++ b/go/livestream_cache.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+const LivestreamCacheTTL = 10 * time.Second
+
+type LivestreamCacheData struct {
+	livestream *LivestreamModel
+	expiresAt  time.Time
+}
+
+var livestreamCacheMap = make(map[int64]LivestreamCacheData)
+var livestreamCacheMu = sync.RWMutex{}
+
+func fetchLivestreams(ctx context.Context, tx sqlx.QueryerContext, ids []int64) (map[int64]*LivestreamModel, error) {
+	if len(ids) == 0 {
+		return make(map[int64]*LivestreamModel), nil
+	}
+
+	livestreamResp := make(map[int64]*LivestreamModel)
+	notFoundIds := func() []int64 {
+		livestreamCacheMu.RLock()
+		defer livestreamCacheMu.RUnlock()
+
+		var notFoundIds []int64
+		for _, livestreamId := range ids {
+			data, ok := livestreamCacheMap[livestreamId]
+			if !ok {
+				notFoundIds = append(notFoundIds, livestreamId)
+				continue
+			}
+			if time.Now().After(data.expiresAt) {
+				notFoundIds = append(notFoundIds, livestreamId)
+				continue
+			}
+			livestreamResp[livestreamId] = data.livestream
+		}
+		return notFoundIds
+	}()
+
+	if len(notFoundIds) == 0 {
+		return livestreamResp, nil
+	}
+
+	livestreamModels := []*LivestreamModel{}
+	{
+		query, args, err := sqlx.In("SELECT * FROM livestreams WHERE id IN (?)", notFoundIds)
+		if err != nil {
+			return nil, fmt.Errorf("IN query: %w", err)
+		}
+		if err := sqlx.SelectContext(ctx, tx, &livestreamModels, query, args...); err != nil {
+			return nil, fmt.Errorf("SELECT livestreams: %w", err)
+		}
+	}
+
+	livestreamCacheMu.Lock()
+	for _, livestream := range livestreamModels {
+		livestreamResp[livestream.ID] = livestream
+		livestreamCacheMap[livestream.ID] = LivestreamCacheData{
+			livestream: livestream,
+			expiresAt:  time.Now().Add(LivestreamCacheTTL),
+		}
+	}
+	livestreamCacheMu.Unlock()
+
+	return livestreamResp, nil
+}
+
+func fetchLivestream(ctx context.Context, tx sqlx.QueryerContext, id int64) (*LivestreamModel, error) {
+	userById, err := fetchLivestreams(ctx, tx, []int64{id})
+	if err != nil {
+		return nil, err
+	}
+	user, ok := userById[id]
+	if !ok {
+		return nil, fmt.Errorf("livestream %d not found", id)
+	}
+	return user, nil
+}

--- a/go/livestream_cache.go
+++ b/go/livestream_cache.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hatena/godash"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -27,10 +28,11 @@ func fetchLivestreams(ctx context.Context, tx sqlx.QueryerContext, ids []int64) 
 		return make(map[int64]*LivestreamModel), nil
 	}
 
+	uniqIds := godash.Uniq(ids)
 	livestreamResp := make(map[int64]*LivestreamModel)
 	notFoundIds := func() []int64 {
 		var notFoundIds []int64
-		for _, livestreamId := range ids {
+		for _, livestreamId := range uniqIds {
 			livestreamCacheMu.RLock()
 			data, ok := livestreamCacheMap[livestreamId]
 			livestreamCacheMu.RUnlock()

--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -211,6 +211,7 @@ func searchLivestreamsHandler(c echo.Context) error {
 				livestreamIds[i] = keyTaggedLivestream.LivestreamID
 			}
 
+			// ここのINクエリのキャッシュは諦める
 			query, args, err := sqlx.In("SELECT * FROM livestreams WHERE id IN (?) ORDER BY id DESC", livestreamIds)
 			if err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, "failed to construct IN query for livestreams: "+err.Error())

--- a/go/main.go
+++ b/go/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
@@ -140,6 +141,9 @@ func initializeHandler(c echo.Context) error {
 		c.Logger().Warnf("init.sh failed with err=%s", string(out))
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to initialize: "+err.Error())
 	}
+
+	// Livestreamのキャッシュが完全に切れるのを待つ
+	time.Sleep(LivestreamCacheTTL)
 
 	var updateRows []struct {
 		Id          int64  `db:"id"`

--- a/go/reaction_handler.go
+++ b/go/reaction_handler.go
@@ -192,11 +192,11 @@ func fillReactionResponse(ctx context.Context, tx *sqlx.Tx, reactionModel Reacti
 		return Reaction{}, err
 	}
 
-	livestreamModel := LivestreamModel{}
-	if err := tx.GetContext(ctx, &livestreamModel, "SELECT * FROM livestreams WHERE id = ?", reactionModel.LivestreamID); err != nil {
+	livestreamModel, err := fetchLivestream(ctx, tx, reactionModel.LivestreamID)
+	if err != nil {
 		return Reaction{}, err
 	}
-	livestream, err := fillLivestreamResponse(ctx, tx, livestreamModel)
+	livestream, err := fillLivestreamResponse(ctx, tx, *livestreamModel)
 	if err != nil {
 		return Reaction{}, err
 	}

--- a/go/reaction_handler.go
+++ b/go/reaction_handler.go
@@ -95,18 +95,12 @@ func bulkFillReactionResponse(ctx context.Context, tx *sqlx.Tx, reactionModels [
 	if err != nil {
 		return nil, fmt.Errorf("failed to bulkFillUserResponse: %w", err)
 	}
-	livestreamModels := []*LivestreamModel{}
-	{
-		livestreamIds := godash.Map(reactionModels, func(r ReactionModel, _ int) int64 { return r.LivestreamID })
-		query, args, err := sqlx.In("SELECT * FROM livestreams WHERE id IN (?)", livestreamIds)
-		if err != nil {
-			return nil, fmt.Errorf("failed to construct IN query for livestreams: %w", err)
-		}
-		if err := sqlx.SelectContext(ctx, tx, &livestreamModels, query, args...); err != nil {
-			return nil, fmt.Errorf("failed to query livestreams: %w", err)
-		}
+	livestreamIds := godash.Map(reactionModels, func(r ReactionModel, _ int) int64 { return r.LivestreamID })
+	livestreamModels, err := fetchLivestreams(ctx, tx, livestreamIds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetchLivestreams: %w", err)
 	}
-	livestreams, err := bulkFillLivestreamResponse(ctx, tx, livestreamModels)
+	livestreams, err := bulkFillLivestreamResponse(ctx, tx, maps.Values(livestreamModels))
 	if err != nil {
 		return nil, fmt.Errorf("failed to bulkFillLivestreamResponse: %w", err)
 	}

--- a/go/stats_handler.go
+++ b/go/stats_handler.go
@@ -208,9 +208,9 @@ func getLivestreamStatisticsHandler(c echo.Context) error {
 	}
 	defer tx.Rollback()
 
-	var livestream LivestreamModel
-	if err := tx.GetContext(ctx, &livestream, "SELECT * FROM livestreams WHERE id = ?", livestreamID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+	livestream, err := fetchLivestream(ctx, tx, livestreamID)
+	if err != nil {
+		if errors.Is(err, ErrLivestreamNotFound) {
 			return echo.NewHTTPError(http.StatusBadRequest, "cannot get stats of not found livestream")
 		} else {
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get livestream: "+err.Error())


### PR DESCRIPTION
186071

```
2023-11-28T17:06:37.529Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-28T17:06:37.529Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-28T17:06:37.529Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-28T17:06:37.529Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-28T17:06:53.669Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-28T17:07:00.028Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-28T17:07:00.028Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-28T17:08:00.031Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-28T17:08:00.032Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "chiyo150", "livestream_id": 7682, "error": "Post \"https://yuitakahashi0.u.isucon.dev:443/api/livestream/7682/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T17:08:00.032Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "suzukishohei2", "livestream_id": 8169, "error": "Post \"https://katominoru0.u.isucon.dev:443/api/livestream/8169/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T17:08:00.033Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "ryohei080", "livestream_id": 8123, "error": "Post \"https://yoichitakahashi0.u.isucon.dev:443/api/livestream/8123/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T17:08:00.033Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "shoheisato0", "livestream_id": 7527, "error": "Post \"https://mikimatsuda0.u.isucon.dev:443/api/livestream/7527/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T17:08:00.033Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "satomigoto1", "livestream_id": 8148, "error": "Post \"https://rei140.u.isucon.dev:443/api/livestream/8148/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-28T17:08:00.825Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-28T17:08:00.825Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-28T17:08:00.825Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-28T17:08:00.825Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-28T17:08:00.828Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 953}
```