### PR TITLE
JOINしなくていい

### DIFF
--- a/go/stats_handler.go
+++ b/go/stats_handler.go
@@ -259,7 +259,7 @@ func getLivestreamStatisticsHandler(c echo.Context) error {
 
 	// スパム報告数
 	var totalReports int64
-	if err := tx.GetContext(ctx, &totalReports, `SELECT COUNT(*) FROM livecomment_reports livestream_id = ?`, livestreamID); err != nil && !errors.Is(err, sql.ErrNoRows) {
+	if err := tx.GetContext(ctx, &totalReports, `SELECT COUNT(*) FROM livecomment_reports WHERE livestream_id = ?`, livestreamID); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to count total spam reports: "+err.Error())
 	}
 

--- a/go/stats_handler.go
+++ b/go/stats_handler.go
@@ -241,13 +241,13 @@ func getLivestreamStatisticsHandler(c echo.Context) error {
 
 	// 視聴者数算出
 	var viewersCount int64
-	if err := tx.GetContext(ctx, &viewersCount, `SELECT COUNT(*) FROM livestreams l INNER JOIN livestream_viewers_history h ON h.livestream_id = l.id WHERE l.id = ?`, livestreamID); err != nil && !errors.Is(err, sql.ErrNoRows) {
+	if err := tx.GetContext(ctx, &viewersCount, `SELECT COUNT(*) FROM livestream_viewers_history WHERE livestream_id = ?`, livestreamID); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to count livestream viewers: "+err.Error())
 	}
 
 	// 最大チップ額
 	var maxTip int64
-	if err := tx.GetContext(ctx, &maxTip, `SELECT IFNULL(MAX(tip), 0) FROM livestreams l INNER JOIN livecomments l2 ON l2.livestream_id = l.id WHERE l.id = ?`, livestreamID); err != nil && !errors.Is(err, sql.ErrNoRows) {
+	if err := tx.GetContext(ctx, &maxTip, `SELECT IFNULL(MAX(tip), 0) FROM livecomments WHERE livestream_id = ?`, livestreamID); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to find maximum tip livecomment: "+err.Error())
 	}
 
@@ -259,7 +259,7 @@ func getLivestreamStatisticsHandler(c echo.Context) error {
 
 	// スパム報告数
 	var totalReports int64
-	if err := tx.GetContext(ctx, &totalReports, `SELECT COUNT(*) FROM livestreams l INNER JOIN livecomment_reports r ON r.livestream_id = l.id WHERE l.id = ?`, livestreamID); err != nil && !errors.Is(err, sql.ErrNoRows) {
+	if err := tx.GetContext(ctx, &totalReports, `SELECT COUNT(*) FROM livecomment_reports livestream_id = ?`, livestreamID); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to count total spam reports: "+err.Error())
 	}
 


### PR DESCRIPTION
200701

```
2023-11-29T12:03:55.546Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-29T12:03:55.546Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-29T12:03:55.546Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-29T12:03:55.546Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-29T12:04:11.425Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-29T12:04:17.789Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-29T12:04:17.789Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-29T12:05:17.789Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-29T12:05:17.791Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "minoru750", "livestream_id": 8149, "error": "Post \"https://xabe0.u.isucon.dev:443/api/livestream/8149/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T12:05:17.792Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "jun800", "livestream_id": 7681, "error": "Post \"https://mikimatsuda0.u.isucon.dev:443/api/livestream/7681/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T12:05:17.792Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "chiyo890", "livestream_id": 7698, "error": "Post \"https://yamazakikyosuke0.u.isucon.dev:443/api/livestream/7698/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T12:05:17.792Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "rtakahashi0", "livestream_id": 8126, "error": "Post \"https://ghasegawa0.u.isucon.dev:443/api/livestream/8126/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T12:05:17.792Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "itojun1", "livestream_id": 7558, "error": "Post \"https://hanako600.u.isucon.dev:443/api/livestream/7558/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T12:05:17.793Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "nanamifujita0", "livestream_id": 8104, "error": "Post \"https://rikanakajima0.u.isucon.dev:443/api/livestream/8104/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T12:05:18.560Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-29T12:05:18.560Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-29T12:05:18.560Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-29T12:05:18.560Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-29T12:05:18.563Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 1022}
```