### PR TITLE
statsでトランザクション剥がしたい

### DIFF
--- a/go/stats_handler.go
+++ b/go/stats_handler.go
@@ -71,11 +71,7 @@ func getUserStatisticsHandler(c echo.Context) error {
 	// ユーザごとに、紐づく配信について、累計リアクション数、累計ライブコメント数、累計売上金額を算出
 	// また、現在の合計視聴者数もだす
 
-	tx, err := dbConn.BeginTxx(ctx, nil)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to begin transaction: "+err.Error())
-	}
-	defer tx.Rollback()
+	tx := dbConn
 
 	var user UserModel
 	if err := tx.GetContext(ctx, &user, "SELECT * FROM users WHERE name = ?", username); err != nil {
@@ -172,10 +168,6 @@ func getUserStatisticsHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to find favorite emoji: "+err.Error())
 	}
 
-	if err := tx.Commit(); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to commit: "+err.Error())
-	}
-
 	stats := UserStatistics{
 		Rank:              rank,
 		ViewersCount:      viewersCount,
@@ -200,11 +192,7 @@ func getLivestreamStatisticsHandler(c echo.Context) error {
 	}
 	livestreamID := int64(id)
 
-	tx, err := dbConn.BeginTxx(ctx, nil)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to begin transaction: "+err.Error())
-	}
-	defer tx.Rollback()
+	tx := dbConn
 
 	livestream, err := fetchLivestream(ctx, tx, livestreamID)
 	if err != nil {
@@ -259,10 +247,6 @@ func getLivestreamStatisticsHandler(c echo.Context) error {
 	var totalReports int64
 	if err := tx.GetContext(ctx, &totalReports, `SELECT COUNT(*) FROM livecomment_reports WHERE livestream_id = ?`, livestreamID); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to count total spam reports: "+err.Error())
-	}
-
-	if err := tx.Commit(); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to commit: "+err.Error())
 	}
 
 	return c.JSON(http.StatusOK, LivestreamStatistics{


### PR DESCRIPTION
205496

```
2023-11-29T15:48:38.533Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-29T15:48:38.533Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-29T15:48:38.533Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-29T15:48:38.533Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-29T15:48:54.240Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-29T15:49:00.537Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-29T15:49:00.537Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-29T15:50:00.537Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-29T15:50:00.538Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "zsuzuki0", "livestream_id": 7726, "error": "Post \"https://yoko260.u.isucon.dev:443/api/livestream/7726/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T15:50:00.539Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "tomoyayamaguchi0", "livestream_id": 8206, "error": "Post \"https://nakamuraasuka0.u.isucon.dev:443/api/livestream/8206/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T15:50:00.539Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "tmori2", "livestream_id": 8244, "error": "Post \"https://akira250.u.isucon.dev:443/api/livestream/8244/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T15:50:00.539Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "yasuhiro210", "livestream_id": 8230, "error": "Post \"https://ryohei550.u.isucon.dev:443/api/livestream/8230/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T15:50:00.539Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "suzukiyosuke1", "livestream_id": 7586, "error": "Post \"https://kazuyasato0.u.isucon.dev:443/api/livestream/7586/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T15:50:00.540Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "fujiwarashota0", "livestream_id": 7710, "error": "Post \"https://nakamuraryohei0.u.isucon.dev:443/api/livestream/7710/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T15:50:01.358Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-29T15:50:01.358Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-29T15:50:01.359Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-29T15:50:01.359Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-29T15:50:01.362Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 1054}
```