### PR TITLE
トランザクションほぼ全部剥がす

### DIFF
--- a/go/payment_handler.go
+++ b/go/payment_handler.go
@@ -13,19 +13,9 @@ type PaymentResult struct {
 func GetPaymentResult(c echo.Context) error {
 	ctx := c.Request().Context()
 
-	tx, err := dbConn.BeginTxx(ctx, nil)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to begin transaction: "+err.Error())
-	}
-	defer tx.Rollback()
-
 	var totalTip int64
-	if err := tx.GetContext(ctx, &totalTip, "SELECT IFNULL(SUM(tip), 0) FROM livecomments"); err != nil {
+	if err := dbConn.GetContext(ctx, &totalTip, "SELECT IFNULL(SUM(tip), 0) FROM livecomments"); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to count total tip: "+err.Error())
-	}
-
-	if err := tx.Commit(); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to commit: "+err.Error())
 	}
 
 	return c.JSON(http.StatusOK, &PaymentResult{


### PR DESCRIPTION
配信予約以外のトランザクションは剥がしてもベンチマークが通る

207035ぐらいまで出た

```
2023-11-29T15:59:04.882Z	info	isupipe-benchmarker	SSL接続が有効になっています
2023-11-29T15:59:04.882Z	info	isupipe-benchmarker	静的ファイルチェックを行います
2023-11-29T15:59:04.882Z	info	isupipe-benchmarker	静的ファイルチェックが完了しました
2023-11-29T15:59:04.882Z	info	isupipe-benchmarker	webappの初期化を行います
2023-11-29T15:59:20.986Z	info	isupipe-benchmarker	ベンチマーク走行前のデータ整合性チェックを行います
2023-11-29T15:59:27.274Z	info	isupipe-benchmarker	整合性チェックが成功しました
2023-11-29T15:59:27.275Z	info	isupipe-benchmarker	ベンチマーク走行を開始します
2023-11-29T16:00:27.275Z	info	isupipe-benchmarker	ベンチマーク走行を停止します
2023-11-29T16:00:27.276Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "yuisuzuki0", "livestream_id": 7704, "error": "Post \"https://jshimizu0.u.isucon.dev:443/api/livestream/7704/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T16:00:27.276Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "ryohei260", "livestream_id": 7708, "error": "Post \"https://yosuke580.u.isucon.dev:443/api/livestream/7708/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T16:00:27.276Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "hasegawataichi0", "livestream_id": 8226, "error": "Post \"https://nanamimatsumoto0.u.isucon.dev:443/api/livestream/8226/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T16:00:27.277Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "shota030", "livestream_id": 8225, "error": "Post \"https://sasakinaoko0.u.isucon.dev:443/api/livestream/8225/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T16:00:27.277Z	warn	isupipe-benchmarker	ライブコメントを配信に投稿できないため、視聴者が離脱します	{"viewer": "fnakamura2", "livestream_id": 7710, "error": "Post \"https://rikanakajima0.u.isucon.dev:443/api/livestream/7710/livecomment\": context canceled: ベンチマーク走行が継続できないエラーが発生しました"}
2023-11-29T16:00:28.090Z	info	isupipe-benchmarker	ベンチマーク走行終了
2023-11-29T16:00:28.090Z	info	isupipe-benchmarker	最終チェックを実施します
2023-11-29T16:00:28.090Z	info	isupipe-benchmarker	最終チェックが成功しました
2023-11-29T16:00:28.090Z	info	isupipe-benchmarker	重複排除したログを以下に出力します
2023-11-29T16:00:28.093Z	info	isupipe-benchmarker	配信を最後まで視聴できた視聴者数	{"viewers": 1051}
```